### PR TITLE
Use the latest version of WordPress

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 
-ENV wordpress_url https://wordpress.org/wordpress-3.0.tar.gz
+ENV wordpress_url https://wordpress.org/latest.tar.gz
 RUN rpm --rebuilddb 
 RUN yum -y install httpd php php-mysql curl
 RUN curl $wordpress_url > wordpress.tar.gz


### PR DESCRIPTION
Because there's no good reason not to.
